### PR TITLE
More ambigous style-prop typing

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -13,7 +13,7 @@ import {
 import styles from './button.style';
 
 interface Props extends PressableProps {
-  style?: ViewStyle | ViewStyle[];
+  style?: ViewStyle | (ViewStyle | undefined)[];
   title?: string;
   titleProps?: TextProps;
   enableRipple?: boolean;

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -18,7 +18,7 @@ import styles, { DEFAULT_IMAGE_SIZE } from './image.style';
 
 interface Props {
   source: number | { uri: string };
-  style?: ViewStyle & ImageStyle & ViewStyle[] & ImageStyle[];
+  style?: ViewStyle | ImageStyle | (ViewStyle | undefined)[] | (ImageStyle | undefined)[];
   isLoading?: boolean;
   onLoad?: (event: NativeSyntheticEvent<ImageLoadEventData>) => void;
   onError?: (error: NativeSyntheticEvent<ImageErrorEventData>) => void;

--- a/src/components/ImageBackground/ImageBackground.tsx
+++ b/src/components/ImageBackground/ImageBackground.tsx
@@ -18,7 +18,7 @@ import styles, { DEFAULT_IMAGE_SIZE } from './imageBackground.style';
 
 interface Props {
   source: number | { uri: string };
-  style?: ViewStyle & ImageStyle;
+  style?: ViewStyle | ImageStyle | (ViewStyle | undefined)[] | (ImageStyle | undefined)[];
   imageStyle?: ViewStyle & ImageStyle;
   isLoading?: boolean;
   onLoad?: (event: NativeSyntheticEvent<ImageLoadEventData>) => void;

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -19,7 +19,7 @@ export interface DiscoTextInputProps extends TextInputProps {
   titleStyle?: TextStyle;
   titleProps?: TextProps;
   // TextInput props
-  style?: ViewStyle;
+  style?: ViewStyle | (ViewStyle | undefined)[];
   getRef?: (e: RNTextInput | null) => void;
   isPassword: boolean;
   isSecureTextEntry?: boolean;


### PR DESCRIPTION
Allow for more ambiguous typing on the style property. Example:
```
style?: ViewStyle | ImageStyle | (ViewStyle | undefined)[] | (ImageStyle | undefined)[];
```
